### PR TITLE
[Refactor] JWT 토큰을 통해 userId 추출하도록 변경

### DIFF
--- a/src/main/java/com/antique/auth/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/antique/auth/kakao/controller/KakaoLoginController.java
@@ -76,6 +76,8 @@ public class KakaoLoginController {
             // 사용자 정보를 기반으로 등록 또는 로그인
             User user = kakaoService.registerOrLoginUser(userInfo);
 
+            String email = user.getEmail();
+
             // JWT 생성
             String jwtToken = jwtTokenGenerator.generateAccessToken(user.getUserId());
             String refreshToken = jwtTokenGenerator.generateRefreshToken(user.getUserId()); // 리프레시 토큰 생성
@@ -84,7 +86,7 @@ public class KakaoLoginController {
             refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken);
 
             // 로그인 성공 시 사용자 정보와 JWT를 반환
-            return new ResponseEntity<>(new KakaoLoginResponseDTO(user, jwtToken, refreshToken), HttpStatus.OK);
+            return new ResponseEntity<>(new KakaoLoginResponseDTO(email, jwtToken, refreshToken), HttpStatus.OK);
         } catch (Exception e) {
             // 예외 발생 시 적절한 에러 메시지를 반환합니다.
             return new ResponseEntity<>("Login failed: " + e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/antique/auth/kakao/dto/KakaoLoginResponseDTO.java
+++ b/src/main/java/com/antique/auth/kakao/dto/KakaoLoginResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KakaoLoginResponseDTO {
-    private User user;
+    private String email;
     private String jwtToken;
     private String refreshToken;
 }

--- a/src/main/java/com/antique/controller/product/ProductController.java
+++ b/src/main/java/com/antique/controller/product/ProductController.java
@@ -7,6 +7,7 @@ import com.antique.dto.product.ProductInfoDTO;
 import com.antique.dto.product.ProductRequestDTO;
 import com.antique.dto.product.ProductResponseDTO;
 import com.antique.dto.product.ProductUpdateDTO;
+import com.antique.service.jwt.JwtTokenGenerator;
 import com.antique.service.product.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 public class ProductController {
 
     private final ProductService productService;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
     @Operation(summary = "상품 등록", description = "사용자가 새로운 상품을 등록하는 API입니다.")
     @PostMapping("/register")
@@ -74,8 +76,9 @@ public class ProductController {
     @Operation(summary = "사용자가 판매 중인 상품 조회", description = "사용자가 판매 중인 상품 목록을 조회하는 API입니다.")
     @GetMapping("/getByUserId")
     public ResponseEntity<List<ProductGetDTO>> getProductsByUserId(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId) {
+            @Parameter(description = "JWT Access Token", required = true)
+            @RequestHeader("Authorization") String token) {
+        Long userId = jwtTokenGenerator.extractUserId(token); // JWT에서 userId 추출
         List<ProductGetDTO> products = productService.getProductByUserId(userId);
         return ResponseEntity.ok(products);
     }
@@ -117,10 +120,13 @@ public class ProductController {
     @Operation(summary = "상품명으로 상품 검색", description = "상품명으로 상품을 검색하는 API 입니다.")
     @GetMapping("/searchByProductName")
     public ResponseEntity<List<ProductDTO>> searchByProductName(
-            @Parameter(name = "userId", description = "사용자 ID")
-            @RequestParam Long userId,
+            @Parameter(description = "JWT Access Token", required = true)
+            @RequestHeader("Authorization") String token,
             @Parameter(name = "productName", description = "검색하고자 하는 상품명, query string")
             @RequestParam String productName) {
+
+        Long userId = jwtTokenGenerator.extractUserId(token); // JWT에서 userId 추출
+
         // 최근 검색어 저장
         productService.saveRecentSearch(userId, productName);
 
@@ -136,8 +142,11 @@ public class ProductController {
     @Operation(summary = "최근 검색어 조회", description = "최근 검색어를 조회하는 API 입니다.")
     @GetMapping("/getRecentSearches")
     public ResponseEntity<List<String>> getRecentSearches(
-            @Parameter(name = "userId", description = "사용자 ID")
-            @RequestParam Long userId) {
+            @Parameter(description = "JWT Access Token", required = true)
+            @RequestHeader("Authorization") String token) {
+
+        Long userId = jwtTokenGenerator.extractUserId(token); // JWT에서 userId 추출
+
         List<String> recentSearches = productService.getRecentSearches(userId);
 
         // 중복 제거

--- a/src/main/java/com/antique/controller/review/ReviewController.java
+++ b/src/main/java/com/antique/controller/review/ReviewController.java
@@ -3,6 +3,7 @@ package com.antique.controller.review;
 import com.antique.domain.Review;
 import com.antique.dto.review.ReviewRequestDTO;
 import com.antique.dto.user.GetUserReviewDTO;
+import com.antique.service.jwt.JwtTokenGenerator;
 import com.antique.service.review.ReviewService;
 import com.antique.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,8 +23,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "review API", description = "리뷰와 관련된 API 목록 입니다.")
 public class ReviewController {
-    private final UserService userService;
     private final ReviewService reviewService;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
     /*
     * 특정 사용자 리뷰 조회
@@ -31,8 +32,10 @@ public class ReviewController {
     @Operation(summary = "특정 사용자 리뷰 조회 API", description = "특정 사용자의 리뷰를 조회하는 API입니다.")
     @GetMapping("/getUserReviews")
     public List<GetUserReviewDTO> getUserReviews(
-            @Parameter(description="리뷰를 조회하고 싶은 사용자의 ID", required = true)
-            @RequestParam Long userId) {
+            @Parameter(description = "JWT Access Token", required = true)
+            @RequestHeader("Authorization") String token) {
+        Long userId = jwtTokenGenerator.extractUserId(token); // JWT에서 userId 추출
+
         return reviewService.getUserReviews(userId);
     }
 

--- a/src/main/java/com/antique/service/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/antique/service/jwt/JwtTokenGenerator.java
@@ -55,10 +55,13 @@ public class JwtTokenGenerator {
      */
     public Long extractUserId(final String token) {
         try {
+            // Bearer 접두사 제거
+            String jwtToken = token.startsWith("Bearer ") ? token.substring(7) : token;
+
             return Long.parseLong(Jwts.parserBuilder()
                     .setSigningKey(getSigningKey())
                     .build()
-                    .parseClaimsJws(token)
+                    .parseClaimsJws(jwtToken)
                     .getBody()
                     .getSubject());
         } catch (JwtException e) {


### PR DESCRIPTION
## 📄 작업 내용 요약
### 📍기존 방식
userId를 파라미터로 받아 API를 처리했습니다.

### **📍변경**
**1️⃣ Controller 관련**
- JWT 토큰 사용 :  @RequestParam 대신 @RequestHeader를 사용하여 클라이언트가 JWT 토큰을 Authorization 헤더에 포함하도록 변경하였습니다.
- userId 추출 : extractUserId 메서드를 통해 JWT 토큰에서 userId를 추출하여 사용합니다.

**2️⃣ 토큰 처리 메서드 관련**

`String jwtToken = token.startsWith("Bearer ") ? token.substring(7) : token;
`
- extractUserId 메서드에서 Bearer 접두사를 제거한 후, JWT를 파싱하여 userId를 추출합니다.

요약하면, JWT Access Token를 파라미터로 받아 해당 토큰을 통해 userId를 추출하고, 그 정보에 따라 API를 처리합니다.
이러한 리팩토링을 통해 클라이언트는 JWT 토큰을 제공해야 하고, 서버는 이를 통해 userId를 안전하게 추출하여 API를 처리할 수 있습니다.

**3️⃣ 카카오 로그인 관련**
카카오 로그인 및 회원가입시 필요한 정보만 포함하도록 응답 DTO를 수정하였습니다.
[ User 객체, jwtToken, refreshToken ] -> [ user의 이메일, jwtToken, refreshToken ]

## ✅ 참고 사항
- Product와 Review와 관련된 Controller 코드만 변경하였습니다.
- 노션 API 리스트도 변경해놓았으니 확인 부탁드립니다.
- Approve 받지 않아도 Merge 가능하도록 깃허브 설정을 변경해놓았습니다.

## 📎 Issue 번호
closed #69 
