### PR TITLE
Feature/generate access token

### DIFF
--- a/src/main/java/com/antique/config/SecurityConfig.java
+++ b/src/main/java/com/antique/config/SecurityConfig.java
@@ -16,6 +16,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                  "/api/v1/login/**", "/api/v1/oauth2/callback",// 로그인 관련 API 허용
+                                "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/v1/auth/refresh"// Swagger UI 및 OpenAPI 문서 허용
                                 "/api/v1/**",
                                 "/swagger-ui/**", "/v3/api-docs/**" // Swagger UI 및 OpenAPI 문서 허용
                         ).permitAll()

--- a/src/main/java/com/antique/config/SecurityConfig.java
+++ b/src/main/java/com/antique/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                  "/api/v1/login/**", "/api/v1/oauth2/callback",// 로그인 관련 API 허용
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/api/v1/auth/refresh"// Swagger UI 및 OpenAPI 문서 허용
+                                "/api/v1/auth/refresh",// Swagger UI 및 OpenAPI 문서 허용
                                 "/api/v1/**",
                                 "/swagger-ui/**", "/v3/api-docs/**" // Swagger UI 및 OpenAPI 문서 허용
                         ).permitAll()

--- a/src/main/java/com/antique/config/SecurityConfig.java
+++ b/src/main/java/com/antique/config/SecurityConfig.java
@@ -17,6 +17,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                  "/api/v1/login/**", "/api/v1/oauth2/callback",// 로그인 관련 API 허용
                                 "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/v1/auth/refresh"// Swagger UI 및 OpenAPI 문서 허용
+                                "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/auth/refresh",// Swagger UI 및 OpenAPI 문서 허용
                                 "/api/v1/**",
                                 "/swagger-ui/**", "/v3/api-docs/**" // Swagger UI 및 OpenAPI 문서 허용

--- a/src/main/java/com/antique/config/SecurityConfig.java
+++ b/src/main/java/com/antique/config/SecurityConfig.java
@@ -17,11 +17,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                  "/api/v1/login/**", "/api/v1/oauth2/callback",// 로그인 관련 API 허용
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/api/v1/auth/refresh"// Swagger UI 및 OpenAPI 문서 허용
-                                "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/auth/refresh",// Swagger UI 및 OpenAPI 문서 허용
-                                "/api/v1/**",
-                                "/swagger-ui/**", "/v3/api-docs/**" // Swagger UI 및 OpenAPI 문서 허용
+                                "/api/v1/**"
                         ).permitAll()
                         .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 )

--- a/src/main/java/com/antique/controller/login/AuthController.java
+++ b/src/main/java/com/antique/controller/login/AuthController.java
@@ -1,0 +1,28 @@
+package com.antique.controller.login;
+
+
+import com.antique.dto.login.jwt.AccessTokenDTO;
+import com.antique.service.jwt.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@Tag(name = "인증 API", description = "JWT 인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * Refresh Token을 이용한 Access Token 재발급
+     */
+    @Operation(summary = "Access Token 재발급", description = "만료된 Access Token을 Refresh Token을 이용해 재발급합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessTokenDTO> refreshAccessToken(@RequestParam String refreshToken) {
+        return ResponseEntity.ok(authService.refreshAccessToken(refreshToken));
+    }
+}

--- a/src/main/java/com/antique/controller/login/GoogleLoginController.java
+++ b/src/main/java/com/antique/controller/login/GoogleLoginController.java
@@ -1,4 +1,4 @@
-package com.antique.controller.user;
+package com.antique.controller.login;
 
 import com.antique.dto.login.google.GoogleAccountProfileResponse;
 import com.antique.dto.login.google.GoogleLoginDTO;

--- a/src/main/java/com/antique/dto/login/jwt/AccessTokenDTO.java
+++ b/src/main/java/com/antique/dto/login/jwt/AccessTokenDTO.java
@@ -1,0 +1,14 @@
+package com.antique.dto.login.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessTokenDTO {
+    private String message;
+    private int statusCode;
+    private String accessToken;
+}

--- a/src/main/java/com/antique/exception/CommonErrorCode.java
+++ b/src/main/java/com/antique/exception/CommonErrorCode.java
@@ -25,10 +25,6 @@ public enum CommonErrorCode implements ErrorCode {
     GOOGLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "Google Access Token 요청에 실패했습니다."),
     GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
-
-    GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
     KAKAO_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Kakao 리다이렉트 요청에 실패했습니다.");
 

--- a/src/main/java/com/antique/exception/CommonErrorCode.java
+++ b/src/main/java/com/antique/exception/CommonErrorCode.java
@@ -25,6 +25,10 @@ public enum CommonErrorCode implements ErrorCode {
     GOOGLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "Google Access Token 요청에 실패했습니다."),
     GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
+
+    GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
     KAKAO_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Kakao 리다이렉트 요청에 실패했습니다.");
 

--- a/src/main/java/com/antique/exception/CommonErrorCode.java
+++ b/src/main/java/com/antique/exception/CommonErrorCode.java
@@ -25,9 +25,7 @@ public enum CommonErrorCode implements ErrorCode {
     GOOGLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "Google Access Token 요청에 실패했습니다."),
     GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
-
-    GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
     KAKAO_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Kakao 리다이렉트 요청에 실패했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/antique/exception/CommonErrorCode.java
+++ b/src/main/java/com/antique/exception/CommonErrorCode.java
@@ -24,6 +24,10 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "유효하지 않은 파라미터입니다. 입력값을 확인해주세요."),
     GOOGLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "Google Access Token 요청에 실패했습니다."),
     GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
+
+    GOOGLE_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Google 리다이렉트 요청에 실패했습니다."),
     KAKAO_REDIRECT_FAILED(HttpStatus.BAD_REQUEST, "Kakao 리다이렉트 요청에 실패했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/antique/service/jwt/AuthService.java
+++ b/src/main/java/com/antique/service/jwt/AuthService.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {

--- a/src/main/java/com/antique/service/jwt/AuthService.java
+++ b/src/main/java/com/antique/service/jwt/AuthService.java
@@ -1,0 +1,43 @@
+package com.antique.service.jwt;
+
+import com.antique.dto.login.jwt.AccessTokenDTO;
+import com.antique.exception.BaseException;
+import com.antique.exception.CommonErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenGenerator jwtTokenGenerator;
+    private final RefreshTokenService refreshTokenService;
+
+    /**
+     * Refresh Token을 이용해 Access Token 재발급
+     */
+    public AccessTokenDTO refreshAccessToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BaseException(CommonErrorCode.INVALID_TOKEN);
+        }
+
+        // Refresh Token에서 userId 추출
+        Long userId = jwtTokenGenerator.extractUserId(refreshToken);
+
+        // Redis에서 저장된 Refresh Token 조회
+        String storedRefreshToken = refreshTokenService.getRefreshToken(userId);
+
+        // 클라이언트가 보낸 Refresh Token과 Redis에 저장된 Refresh Token 비교
+        if (!refreshToken.equals(storedRefreshToken)) {
+            throw new BaseException(CommonErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 새로운 Access Token 발급
+        String newAccessToken = jwtTokenGenerator.generateAccessToken(userId);
+
+        return new AccessTokenDTO("Access Token 재발급 완료", HttpStatus.OK.value(), newAccessToken);
+    }
+}

--- a/src/main/java/com/antique/service/login/google/GoogleLoginService.java
+++ b/src/main/java/com/antique/service/login/google/GoogleLoginService.java
@@ -3,7 +3,6 @@ package com.antique.service.login.google;
 import com.antique.domain.User;
 import com.antique.dto.login.google.GoogleAccountProfileResponse;
 import com.antique.dto.login.google.GoogleLoginDTO;
-import com.antique.dto.user.UserResponseDTO;
 import com.antique.repository.UserRepository;
 import com.antique.service.jwt.JwtTokenGenerator;
 import com.antique.service.jwt.RefreshTokenService;

--- a/src/test/java/com/antique/service/jwt/AuthServiceTest.java
+++ b/src/test/java/com/antique/service/jwt/AuthServiceTest.java
@@ -1,0 +1,92 @@
+package com.antique.service.jwt;
+
+import com.antique.dto.login.jwt.AccessTokenDTO;
+import com.antique.exception.BaseException;
+import com.antique.exception.CommonErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService; // 테스트할 객체
+
+    @Mock
+    private JwtTokenGenerator jwtTokenGenerator;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    void testRefreshAccessToken_Success() {
+        // Given
+        String validRefreshToken = "valid_refresh_token";
+        Long userId = 1L;
+        String newAccessToken = "new_access_token";
+
+        when(jwtTokenGenerator.extractUserId(validRefreshToken)).thenReturn(userId);
+        when(refreshTokenService.getRefreshToken(userId)).thenReturn(validRefreshToken);
+        when(jwtTokenGenerator.generateAccessToken(userId)).thenReturn(newAccessToken);
+
+        // When
+        AccessTokenDTO result = authService.refreshAccessToken(validRefreshToken);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getMessage()).isEqualTo("Access Token 재발급 완료");
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+
+        // 호출 검증
+        verify(jwtTokenGenerator, times(1)).extractUserId(validRefreshToken);
+        verify(refreshTokenService, times(1)).getRefreshToken(userId);
+        verify(jwtTokenGenerator, times(1)).generateAccessToken(userId);
+    }
+
+    @Test
+    void testRefreshAccessToken_InvalidToken() {
+        // Given: null 또는 빈 Refresh Token
+        String invalidRefreshToken = "";
+
+        // When & Then
+        assertThatThrownBy(() -> authService.refreshAccessToken(invalidRefreshToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(CommonErrorCode.INVALID_TOKEN.getMessage());
+
+        // jwtTokenGenerator, refreshTokenService 호출되지 않음
+        verify(jwtTokenGenerator, never()).extractUserId(anyString());
+        verify(refreshTokenService, never()).getRefreshToken(anyLong());
+        verify(jwtTokenGenerator, never()).generateAccessToken(anyLong());
+    }
+
+    @Test
+    void testRefreshAccessToken_RefreshTokenMismatch() {
+        // Given
+        String providedRefreshToken = "old-token";
+        String storedRefreshToken = "different-token"; // 다른 값
+        Long userId = 1L;
+
+        when(jwtTokenGenerator.extractUserId(providedRefreshToken)).thenReturn(userId);
+        when(refreshTokenService.getRefreshToken(userId)).thenReturn(storedRefreshToken);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.refreshAccessToken(providedRefreshToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(CommonErrorCode.REFRESH_TOKEN_MISMATCH.getMessage());
+
+        // 호출 검증
+        verify(jwtTokenGenerator, times(1)).extractUserId(providedRefreshToken);
+        verify(refreshTokenService, times(1)).getRefreshToken(userId);
+        verify(jwtTokenGenerator, never()).generateAccessToken(anyLong()); // Access Token 생성되지 않아야 함
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- access token의 유효 기간이 1시간으로 측정되어 있는데, 이를 이용해서 controller에 요청을 보낸다.
- 하지만 access token이 만료되면 요청을 더 이상 보낼 수 없음 → 그럴 때마다 refreshToken을 이용해서 클라이언트가 access token을 꾸준히 갱신해야 한다.

⇒ access token을 갱신하는 api를 개발하였음.


## 📎 Issue 번호
<!-- closed #번호 -->
closed #64 