### PR TITLE
refactor : redis가 잘 연결되었는지 검사하는 테스트 코드 삭제

### DIFF
--- a/src/main/java/com/antique/service/jwt/RefreshTokenService.java
+++ b/src/main/java/com/antique/service/jwt/RefreshTokenService.java
@@ -48,16 +48,4 @@ public class RefreshTokenService {
     public void deleteRefreshToken(Long userId) {
         redisTemplate.delete(getKey(userId));
     }
-
-    @PostConstruct
-    public void testRedisConnection() {
-        try {
-            redisTemplate.opsForValue().set("testKey", "Hello AWS Redis", Duration.ofMinutes(10));
-            String value = redisTemplate.opsForValue().get("testKey");
-            System.out.println("✅ Redis 저장 및 조회 성공: " + value);
-        } catch (Exception e) {
-            System.err.println("❌ Redis 저장 실패: " + e.getMessage());
-            e.printStackTrace();
-        }
-    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- 제목 그대로, 원래는 프로그램을 실행할 때 redis가 잘 연결되었는지 검사하는 테스트 코드가 있었는데, 이를 삭제하였다.
- elasticache 에서 만든 redis가 기본 설정으로 로컬에서 접속이 안 되어서, application.properties를 분리해서, 배포 전용 설정 파일에는 elasticache 내 redis를 사용하고, 로컬 전용 배포 파일에는 localhost 내 redis를 사용하면 된다.


## 📎 Issue 번호
<!-- closed #번호 -->
